### PR TITLE
#13 service層でrepositoryのエラーを判定する

### DIFF
--- a/internal/services/errors.go
+++ b/internal/services/errors.go
@@ -12,3 +12,27 @@ func (e *ValidationError) Error() string {
 	}
 	return e.Message
 }
+
+// NotFoundError はリソースが見つからないことを表します。
+type NotFoundError struct {
+	Message string
+}
+
+func (e *NotFoundError) Error() string {
+	if e == nil {
+		return "not found"
+	}
+	return e.Message
+}
+
+// InternalError は内部エラーを表します（外部に詳細を漏らさないためのラップ）。
+type InternalError struct {
+	Message string
+}
+
+func (e *InternalError) Error() string {
+	if e == nil {
+		return "internal error"
+	}
+	return e.Message
+}


### PR DESCRIPTION
- closes: nt624/money-buddy#18 
# サービス層でのDBエラーの意味づけと変換

## 概要
サービス層でリポジトリ（DB）から返される生のエラーを解釈し、上位へ渡す際に意味づけされたサービス層エラーへ変換する実装を追加します。これにより、DB固有のエラーメッセージを直接漏らさず、ハンドラ層で型ごとの振る舞い（HTTPステータス等）を明確に処理できます。

## 変更点（要約）
- サービス層に新しいエラー型を追加
  - `NotFoundError`
  - `InternalError`
- `CreateExpense` にリポジトリエラーのマッピング処理を追加
  - `sql.ErrNoRows` → `NotFoundError`
  - 外部キー制約違反（`category_id` を示唆するエラーメッセージ）→ `ValidationError{Message: "category_id is invalid"}`
  - その他のエラー → `InternalError{Message: "internal error"}`
- DBエラー種別のマッピングを検証するユニットテストを追加（モックでリポジトリのエラーを注入）
- ハンドラ層・リポジトリ層は変更していません（要件遵守）

## 変更ファイル
- errors.go — `NotFoundError`, `InternalError` の追加
- expense_service.go — `CreateExpense` にエラーマッピング追加
- expense_service_test.go — DBエラー挙動のテスト追加（テスト名は日本語化）

## 目的（背景・意図）
- サービス層で「意味づけ」を行い、DB固有のメッセージやスタックトレースを上位に露出しないようにするため。
- ハンドラはサービスが返す意味づけ済みのエラー型に基づいてHTTPレスポンスを決定できる（例：NotFound → 404, Validation → 400, Internal → 500）。

## 実装のポイント
- `sql.ErrNoRows` は `errors.Is` で判定。
- 外部キー違反は現状「エラーメッセージの文字列」に含まれる語（`foreign key`, `category`, `category_id`）で検出しています。  
  - 理由：ドライバ固有型に依存せず汎用的に判定するため。
  - 注意：DB ドライバやロケールによってメッセージが変わる可能性があるため、確実性はドライバ固有判定には劣ります。

## テスト
- 追加テスト: `TestCreateExpense_DBErrorMapping`
  - モックリポジトリに以下のエラーを返させ、サービス側で期待するエラー型が返ることを確認します:
    - `sql.ErrNoRows` → `NotFoundError`
    - FK違反を想定したメッセージ → `ValidationError("category_id is invalid")`
    - その他のエラー → `InternalError`
- 実行コマンド:
```bash
cd /Users/nagu/project/money-buddy/money-buddy-backend
go test ./internal/services -v
```

## レビューノート / 懸念事項
- 外部キー違反の検出をより堅牢にするために、将来的にドライバ固有（例: lib/pq の `pq.Error` の `Code` を使う）の判定に切り替えることを提案します。ただし、その場合は DB ドライバへの依存が増えます。
- 同様のエラーマッピングは他のサービスメソッドにも適用可能なので、共通化（ユーティリティ関数化）を検討できます。