### PR TITLE
#15 openapi.yamlを追加する

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -1,0 +1,128 @@
+openapi: "3.0.3"
+info:
+  title: "Money Buddy API"
+  version: "1.0.0"
+servers:
+  - url: "http://localhost:8080"
+tags:
+  - name: "expenses"
+    description: "Expense operations"
+paths:
+  /expenses:
+    post:
+      tags:
+        - "expenses"
+      summary: "Create an expense"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateExpenseRequest'
+      responses:
+        "201":
+          description: "Expense created"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateExpenseResponse'
+        "400":
+          description: "Validation Error"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: "Internal Server Error"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    get:
+      tags:
+        - "expenses"
+      summary: "List expenses"
+      parameters: []
+      responses:
+        "200":
+          description: "List of expenses"
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  expenses:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Expense'
+                required:
+                  - expenses
+        "500":
+          description: "Internal Server Error"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+components:
+  schemas:
+    Expense:
+      type: object
+      properties:
+        id:
+          type: integer
+        amount:
+          type: integer
+          minimum: 1
+        category_id:
+          type: integer
+          minimum: 1
+        memo:
+          type: string
+        spent_at:
+          type: string
+          format: date
+      required:
+        - id
+        - amount
+        - category_id
+        - memo
+        - spent_at
+
+    CreateExpenseRequest:
+      type: object
+      properties:
+        amount:
+          type: integer
+          minimum: 1
+        category_id:
+          type: integer
+          minimum: 1
+        memo:
+          type: string
+        spent_at:
+          type: string
+          format: date
+      required:
+        - amount
+        - category_id
+        - spent_at
+
+    CreateExpenseResponse:
+      type: object
+      properties:
+        expense:
+          $ref: '#/components/schemas/Expense'
+      required:
+        - expense
+
+    ErrorResponse:
+      type: object
+      properties:
+        code:
+          type: string
+        message:
+          type: string
+      required:
+        - code
+        - message


### PR DESCRIPTION
- closes: nt624/money-buddy#19 
## 概要
API 仕様を明文化するため、OpenAPI 3.0.3 仕様書を追加します。実装は変更せず、ドキュメントのみの追加です。

## 追加ファイル
- openapi.yaml

## 変更内容
- 新規追加: openapi.yaml
  - `POST /expenses` と `GET /expenses` の仕様を定義
  - リクエスト/レスポンスのスキーマは `components/schemas` にまとめて定義
  - 共通エラー用スキーマ `ErrorResponse` を定義
  - `info`、`servers`（`http://localhost:8080`）、`tags` を含む

## 仕様の要点
- `POST /expenses`
  - リクエスト（`application/json`）:
    - `amount`: integer, 必須, minimum: 1
    - `category_id`: integer, 必須, minimum: 1
    - `memo`: string, 任意
    - `spent_at`: string, format: date, 必須
  - 正常: `201`（登録された `expense` を返す）
  - 異常: `400`（Validation Error）、`500`（Internal Server Error）

- `GET /expenses`
  - クエリパラメータなし
  - 正常: `200`（`expenses` 配列を返す、0件可）
  - 異常: `500`（Internal Server Error）

- 共通レスポンス:
  - `ErrorResponse`:
    - `code`: string
    - `message`: string

## 影響範囲
- 実装コードに変更はありません。ドキュメント追加のみのため、既存の動作に影響はありません。
- スキーマは既存の実装（例: expense.go, expense_handler.go）に合わせて作成しています。

## 検証（確認済み）
- YAML を作成し、エンドポイントとスキーマが既存モデルと整合することを目視で確認しました。