### PR TITLE
#17 CORS対応する

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -12,6 +12,20 @@ import (
 
 func main() {
 	r := gin.Default()
+
+	r.Use(func(c *gin.Context) {
+		c.Writer.Header().Set("Access-Control-Allow-Origin", "http://localhost:3000")
+		c.Writer.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+		c.Writer.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+
+		if c.Request.Method == "OPTIONS" {
+			c.AbortWithStatus(204)
+			return
+		}
+
+		c.Next()
+	})
+
 	dbConn, err := db.NewDB()
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
- closes: nt624/money-buddy#20 
## 概要

フロントエンド（Next.js）からバックエンド API（Gin）を呼び出した際に、
ブラウザの CORS 制約によりリクエストがブロックされていたため、
バックエンド側に CORS 対応を追加しました。

本PRでは Gin のミドルウェアとして CORS 設定を行い、
`localhost:3000` からの API 呼び出しを許可しています。

---

## 背景

- フロントエンド（http://localhost:3000）から
  バックエンド（http://localhost:8080）へ fetch を行うと、
  ブラウザの同一オリジンポリシーによりリクエストがブロックされていた
- API 自体は正常にレスポンスを返していたが、
  ブラウザ側でレスポンスが破棄されていた

---

## 対応内容

- `cmd/server/main.go` に Gin ミドルウェアとして CORS 設定を追加
- 以下を許可
  - Origin: `http://localhost:3000`
  - Methods: `GET, POST, OPTIONS`
  - Headers: `Content-Type`
- Preflight（OPTIONS）リクエストに対して 204 を返すよう対応

---

## 実装方針

- CORS はアプリ全体に関わる横断的関心事のため、Handler ではなく main.go で対応
- `http.ListenAndServe` は使用せず、Gin の `r.Run()` に統一
- 将来的には環境変数や `gin-contrib/cors` への置き換えを想定

---

## 動作確認

- [x] ブラウザから GET /expenses が成功すること
- [x] CORS エラーが発生しないこと
- [x] 既存 API の挙動に影響がないこと

---

## 今後

- フロントエンドから POST /expenses の実装を行う
- 本番環境向けに Origin 設定を環境変数化する
