### PR TITLE
#21 カテゴリーIDのバリデーションを追加する

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -33,10 +33,10 @@ func main() {
 
 	queries := dbgen.New(dbConn)
 	repo := repositories.NewExpenseRepositorySQLC(queries)
-	service := services.NewExpenseService(repo)
+	categoryRepo := repositories.NewCategoryRepositorySQLC(queries)
+	service := services.NewExpenseService(repo, categoryRepo)
 	handlers.NewExpenseHandler(r, service)
 
-	categoryRepo := repositories.NewCategoryRepositorySQLC(queries)
 	categoryService := services.NewCategoryService(categoryRepo)
 	handlers.NewCategoryHandler(r, categoryService)
 

--- a/db/generated/categories.sql.go
+++ b/db/generated/categories.sql.go
@@ -9,6 +9,21 @@ import (
 	"context"
 )
 
+const categoryExists = `-- name: CategoryExists :one
+SELECT EXISTS (
+  SELECT 1 
+  FROM categories 
+  WHERE id = $1
+)
+`
+
+func (q *Queries) CategoryExists(ctx context.Context, id int32) (bool, error) {
+	row := q.db.QueryRowContext(ctx, categoryExists, id)
+	var exists bool
+	err := row.Scan(&exists)
+	return exists, err
+}
+
 const listCategories = `-- name: ListCategories :many
 SELECT
   id,

--- a/db/query/categories.sql
+++ b/db/query/categories.sql
@@ -4,3 +4,10 @@ SELECT
   name
 FROM categories
 ORDER BY id;
+
+-- name: CategoryExists :one
+SELECT EXISTS (
+  SELECT 1 
+  FROM categories 
+  WHERE id = $1
+);

--- a/internal/repositories/category_repository.go
+++ b/internal/repositories/category_repository.go
@@ -8,4 +8,5 @@ import (
 
 type CategoryRepository interface {
 	ListCategories(ctx context.Context) ([]models.Category, error)
+	CategoryExists(ctx context.Context, id int32) (bool, error)
 }

--- a/internal/repositories/category_repository_sqlc.go
+++ b/internal/repositories/category_repository_sqlc.go
@@ -35,3 +35,7 @@ func dbCategoryToModel(c db.ListCategoriesRow) models.Category {
 		Name: c.Name,
 	}
 }
+
+func (r *CategoryRepositorySQLC) CategoryExists(ctx context.Context, id int32) (bool, error) {
+	return r.q.CategoryExists(ctx, id)
+}


### PR DESCRIPTION
- closes: nt624/money-buddy#22 
## 概要
- `CreateExpense` にカテゴリ存在チェックを追加し、存在しない `category_id` の場合はバリデーションエラーにします。
- サービスの依存注入を拡張し、`CategoryRepository` を用いて `CategoryExists` を参照します。
- テストを更新・追加して、存在チェックとエラー時の動作を検証します。

## 変更内容
- expense_service.go
  - **依存注入**: `expenseService` に `categoryRepo repositories.CategoryRepository` を追加
  - **コンストラクタ**: `NewExpenseService(repo, categoryRepo)` に変更
  - **存在チェック**: `CategoryExists(ctx, id)` による `category_id` の存在確認を追加（存在しない場合は `ValidationError("category_id is invalid")`）
  - **エラー扱い**: 参照時の DB/Repo エラーは `InternalError` として扱う
- main.go
  - **サービス初期化**: `categoryRepo := repositories.NewCategoryRepositorySQLC(queries)` を作成し、`NewExpenseService(repo, categoryRepo)` に注入
- expense_service_test.go
  - **モック追加**: `mockCategoryRepo` を追加（`CategoryExists` を制御）
  - **テスト更新**: 既存ケースにカテゴリ存在の前提を反映、未実装スキップを解除
  - **テスト追加**: `CategoryExists` がエラーを返す場合に `InternalError` を返すテストを追加

## バリデーション仕様
- **件数制約**: `amount` が必須・1以上・上限 `1,000,000,000`
- **カテゴリ**: `category_id` が必須・1以上・DB上で存在することが必須
- **日付**: `spent_at` が必須・`RFC3339` または `YYYY-MM-DD` を許容（ゼロ時刻は不可）
- **メモ**: 最大長 `5000` 文字
- エラー時の型は既存ポリシー（`ValidationError`/`InternalError`/`NotFoundError`）に準拠

## テスト
- `TestCreateExpenseValidation`: カテゴリ未存在時は `ValidationError`、正常系はカテゴリを存在扱いにして `repo` が呼ばれることを確認
- `TestCreateExpense_DBErrorMapping`: 既存の DB エラーマッピングテストにカテゴリ存在前提を追加
- `TestCreateExpense_CategoryExistsError`: 参照時エラーは `InternalError` を返し、`repo` は呼ばれないことを確認

## 動作確認
```zsh
# ビルド
go build ./...

# テスト（サービス配下）
go test ./internal/services
```

## 影響範囲
- `ExpenseService` のコンストラクタシグネチャが変更（呼び出し側で `CategoryRepository` の注入が必要）
- 既存のハンドラ・リポジトリは非破壊（main.go の初期化のみ追加）

## 今後の拡張
- `CreateExpense` に `context.Context` を受け渡す形へ変更（キャンセル/タイムアウト対応）
- openapi.yaml にカテゴリ存在エラーの応答例を追記（必要なら）
- カテゴリ関連の E2E テスト/Seed データの整備（必要なら対応）