### PR TITLE
#29 UpdateとDeleteに関わるSQLを追加する

### DIFF
--- a/db/query/expenses.sql
+++ b/db/query/expenses.sql
@@ -35,3 +35,36 @@ SELECT
 FROM expenses e
 JOIN categories c ON e.category_id = c.id
 WHERE e.id = $1;
+
+-- name: GetExpenseByID :one
+SELECT
+  id,
+  amount,
+  category_id,
+  memo,
+  spent_at,
+  status
+FROM expenses
+WHERE id = $1;
+
+-- name: UpdateExpense :exec
+UPDATE expenses
+SET
+  amount = $2,
+  category_id = $3,
+  memo = $4,
+  spent_at = $5,
+  status = $6,
+  update_at = now()
+WHERE id = $1;
+
+-- name: UpdateExpenseStatus :exec
+UPDATE expenses
+SET
+  status = $2,
+  update_at = now()
+WHERE id = $1;
+
+-- name: DeleteExpense :exec
+DELETE FROM expenses
+WHERE id = $1;


### PR DESCRIPTION
- closes: nt624/money-buddy#27 
**概要**
- expenses に更新・削除系のSQLを追加し、sqlcの生成コードを更新。
- `-- name:` メタデータコメントの全角スペースに起因する「invalid metadata」を修正。

**変更内容**
- 追加したクエリ（expenses.sql）:
  - `GetExpenseByID :one`
  - `UpdateExpense :exec`
  - `UpdateExpenseStatus :exec`
  - `DeleteExpense :exec`
- 生成物（expenses.sql.go）:
  - `GetExpenseByID(ctx context.Context, id int32) (GetExpenseByIDRow, error)`
  - `UpdateExpense(ctx context.Context, arg UpdateExpenseParams) error`
  - `UpdateExpenseStatus(ctx context.Context, arg UpdateExpenseStatusParams) error`
  - `DeleteExpense(ctx context.Context, id int32) error`
- メタデータ修正:
  - `--　name: DeleteExpense :exec`（全角スペース）→ `-- name: DeleteExpense :exec`（ASCIIスペース）

**背景 / 目的**
- サービス層/ハンドラでの支出更新・削除機能の実装に必要なクエリを整備。
- sqlc で発生していた「invalid metadata」エラーの原因（全角スペース混入）を除去。

**動作確認**
- コード生成（必要なら再生成）:
  - `sqlc generate`
- ビルド・テスト:
  - `go build money-buddy.`
  - `go test money-buddy.`
- 既存スキーマの変更はなし。生成コードの型・関数が期待通り出力されることを確認。

**影響範囲**
- スキーマ変更なし、既存APIへの破壊的変更なし。
- 新規クエリ追加とコメント修正のみ。既存の参照箇所への影響は最小。

**運用上の注意**
- sqlc メタデータは必ず ASCII の `-- name:` を使用（全角スペースやUnicodeダッシュは不可）。
- 似た問題の検出コマンド例:
  - `grep -nRP '[^\\x00-\\x7F]' db/query`（非ASCII検出）
  - `grep -nR -- '-- name:' db/query`（メタデータ一覧確認）