### PR TITLE
#44 Expensesテーブルにuser_idを追加する

### DIFF
--- a/db/query/expenses.sql
+++ b/db/query/expenses.sql
@@ -1,12 +1,13 @@
 -- name: CreateExpense :one
 INSERT INTO expenses (
+  user_id,
   amount,
   category_id,
   memo,
   spent_at,
   status
 ) VALUES (
-  $1, $2, $3, $4, $5
+  $1, $2, $3, $4, $5, $6
 )
 RETURNING id;
 
@@ -21,6 +22,7 @@ SELECT
   c.name AS category_name
 FROM expenses e
 JOIN categories c ON e.category_id = c.id
+WHERE e.user_id = $1
 ORDER BY spent_at DESC;
 
 -- name: GetExpenseWithCategoryByID :one
@@ -34,7 +36,7 @@ SELECT
   c.name AS category_name
 FROM expenses e
 JOIN categories c ON e.category_id = c.id
-WHERE e.id = $1;
+WHERE e.user_id = $1 AND e.id = $2;
 
 -- name: GetExpenseByID :one
 SELECT
@@ -45,7 +47,7 @@ SELECT
   spent_at,
   status
 FROM expenses
-WHERE id = $1;
+WHERE user_id = $1 AND id = $2;
 
 -- name: UpdateExpense :exec
 UPDATE expenses
@@ -56,15 +58,15 @@ SET
   spent_at = $5,
   status = $6,
   update_at = now()
-WHERE id = $1;
+WHERE id = $1 AND user_id = $7;
 
 -- name: UpdateExpenseStatus :exec
 UPDATE expenses
 SET
   status = $2,
   update_at = now()
-WHERE id = $1;
+WHERE id = $1 AND user_id = $3;
 
 -- name: DeleteExpense :exec
 DELETE FROM expenses
-WHERE id = $1;
+WHERE id = $1 AND user_id = $2;

--- a/db/schema/expenses.sql
+++ b/db/schema/expenses.sql
@@ -1,5 +1,6 @@
 CREATE TABLE expenses (
   id SERIAL PRIMARY KEY,
+  user_id TEXT NOT NULL REFERENCES users(id),
   amount INTEGER NOT NULL,
   category_id INTEGER NOT NULL,
   memo TEXT,


### PR DESCRIPTION
- closes:#44

**目的**
- `expenses`テーブルに`user_id`（TEXT）を追加し、すべてのSQLクエリをユーザー境界前提に変更して「他ユーザーのデータを取得・更新・削除できない」状態にする。

**変更内容**
- expenses.sql: `user_id TEXT NOT NULL REFERENCES users(id)` を追加。
- expenses.sql: sqlc用クエリを全面的に`user_id`スコープ化。
  - SELECT: `WHERE user_id = $1` を必須に。
  - INSERT: `user_id`を必須カラム・第1引数に追加。
  - UPDATE/DELETE: `WHERE id = $1 AND user_id = $N` の形式に統一（既存引数順を壊さない）。
- sqlc再生成済み（expenses.sql.go）で、引数シグネチャが`user_id`前提に更新。

**SQL差分**
- expenses.sql
```diff
+ -- 変更意図: テーブルに user_id(TEXT) を追加し、すべてのクエリでユーザー境界を強制できるようにする。
  CREATE TABLE expenses (
    id SERIAL PRIMARY KEY,
+   user_id TEXT NOT NULL REFERENCES users(id),
    amount INTEGER NOT NULL,
    category_id INTEGER NOT NULL,
    memo TEXT,
    spent_at DATE NOT NULL,
    status TEXT NOT NULL DEFAULT 'confirmed',
    created_at TIMESTAMP NOT NULL DEFAULT now(),
    update_at TIMESTAMP NOT NULL DEFAULT now()
  );
```

- expenses.sql
```diff
--- name: CreateExpense :one
+ -- 変更意図: INSERT 時に必ず user_id を指定し、他ユーザーのデータ混在を防ぐために必須化する。
  INSERT INTO expenses (
+   user_id,
    amount,
    category_id,
    memo,
    spent_at,
    status
  ) VALUES (
-   $1, $2, $3, $4, $5
+   $1, $2, $3, $4, $5, $6
  )
  RETURNING id;

--- name: ListExpenses :many
+ -- 変更意図: SELECT は常に user_id = $1 で絞り込み、他ユーザーのデータを取得できないようにする。
  FROM expenses e
  JOIN categories c ON e.category_id = c.id
- ORDER BY spent_at DESC;
+ WHERE e.user_id = $1
+ ORDER BY spent_at DESC;

--- name: GetExpenseWithCategoryByID :one
+ -- 変更意図: 単一取得も user_id を先頭引数に固定し、id は第2引数にして他ユーザー参照を防止。
- WHERE e.id = $1;
+ WHERE e.user_id = $1 AND e.id = $2;

--- name: GetExpenseByID :one
+ -- 変更意図: user_id を第1引数、id を第2引数にして、他ユーザーのレコードを取得できないようにする。
- WHERE id = $1;
+ WHERE user_id = $1 AND id = $2;

--- name: UpdateExpense :exec
+ -- 変更意図: 更新は id + user_id の両方で WHERE 条件を付与し、他ユーザーのレコード更新を確実に防止する。
- WHERE id = $1;
+ WHERE id = $1 AND user_id = $7;

--- name: UpdateExpenseStatus :exec
+ -- 変更意図: ステータス更新も id + user_id の両方で WHERE 条件。
- WHERE id = $1;
+ WHERE id = $1 AND user_id = $3;

--- name: DeleteExpense :exec
+ -- 変更意図: 削除は id + user_id の両方で WHERE 条件。
- WHERE id = $1;
+ WHERE id = $1 AND user_id = $2;
```

**修正後の SQL（要点）**
- CreateExpense: カラム `user_id, amount, category_id, memo, spent_at, status` / 値 `$1..$6`
- ListExpenses: `WHERE e.user_id = $1`
- GetExpenseWithCategoryByID: `WHERE e.user_id = $1 AND e.id = $2`
- GetExpenseByID: `WHERE user_id = $1 AND id = $2`
- UpdateExpense: `WHERE id = $1 AND user_id = $7`（`id`は従来通り第1引数、`user_id`は末尾）
- UpdateExpenseStatus: `WHERE id = $1 AND user_id = $3`
- DeleteExpense: `WHERE id = $1 AND user_id = $2`

**変更理由**
- 安全性優先: CRUD全てでユーザー境界を強制し、他ユーザーのデータへのアクセス/変更を防止。
- 一貫性: 既存の`fixed_costs`の`user_id`運用に合わせた形。
- 将来拡張: 認証導入前提で、`user_id`はTEXTのまま運用開始可能。

**生成コードへの影響**
- expenses.sql.go
  - `CreateExpense`に`UserID`追加。
  - `ListExpenses(ctx, userID string)`へ変更。
  - `GetExpenseByID`/`GetExpenseWithCategoryByID`は`UserID + ID`のパラメータ構造体に変更。
  - `UpdateExpense`/`UpdateExpenseStatus`/`DeleteExpense`は`UserID`引数が追加され、WHEREが`id + user_id`に。

**テスト/動作確認**
- `go test money-buddy.` で一時的に通らない箇所があり

**移行/互換性**
- 破壊的変更: 既存`expenses`データに`user_id`の付与が必要。
- 推奨移行手順:
  1. 既存レコードへ適切な`user_id`を一括更新（例: シングルユーザー運用中なら既定ユーザーIDを付与）。
  2. アプリ側で新規作成・参照・更新・削除時に必ず`user_id`をパラメータ渡し。
- パフォーマンスは二次優先（必要に応じて`(user_id, id)`の複合インデックス追加を今後検討）。

**補足**
- 認証導入後は`user_id`の型変更（必要なら）やインデックス最適化を検討します。
- 他テーブル（`categories`など）もユーザー境界が必要になれば同方針で対応可能です。