### PR TITLE
#43 ダッシュボード用の支出のサマリSQLを追加する

### DIFF
--- a/db/query/dashboard.sql
+++ b/db/query/dashboard.sql
@@ -7,3 +7,11 @@ FROM users u
 LEFT JOIN fixed_costs fc ON fc.user_id = u.id
 WHERE u.id = $1
 GROUP BY u.id;
+
+-- name: GetMonthlyExpensesSummary :one
+SELECT
+  COALESCE(SUM(CASE WHEN e.status = 'confirmed' THEN e.amount ELSE 0 END), 0) AS confirmed_expenses,
+  COALESCE(SUM(CASE WHEN e.status = 'planned' THEN e.amount ELSE 0 END), 0) AS pending_expenses
+FROM expenses e
+WHERE e.user_id = $1
+  AND DATE_TRUNC('month', e.spent_at) = DATE_TRUNC('month', CURRENT_DATE);


### PR DESCRIPTION
- closes: nt624/money-buddy#35 
## 概要
ダッシュボード向けに当月の支出サマリー（確定・予定）を取得するSQLと生成コードを追加しました。

## 変更内容
- 当月の確定/予定支出合計を返すクエリを追加 dashboard.sql
- sqlc生成コードに`GetMonthlyExpensesSummary`を追加 dashboard.sql.go
