### PR TITLE
#48 userとfixed_costのrepository実装を追加

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -2,9 +2,9 @@ package main
 
 import (
 	dbgen "money-buddy-backend/db/generated"
+	"money-buddy-backend/infra/repository"
 	"money-buddy-backend/internal/db"
 	"money-buddy-backend/internal/handlers"
-	"money-buddy-backend/internal/repositories"
 	"money-buddy-backend/internal/services"
 
 	"github.com/gin-gonic/gin"
@@ -32,8 +32,8 @@ func main() {
 	}
 
 	queries := dbgen.New(dbConn)
-	repo := repositories.NewExpenseRepositorySQLC(queries)
-	categoryRepo := repositories.NewCategoryRepositorySQLC(queries)
+	repo := repository.NewExpenseRepositorySQLC(queries)
+	categoryRepo := repository.NewCategoryRepositorySQLC(queries)
 	service := services.NewExpenseService(repo, categoryRepo)
 	handlers.NewExpenseHandler(r, service)
 

--- a/infra/repository/category_repository_sqlc.go
+++ b/infra/repository/category_repository_sqlc.go
@@ -1,21 +1,22 @@
-package repositories
+package repository
 
 import (
 	"context"
 
 	db "money-buddy-backend/db/generated"
 	"money-buddy-backend/internal/models"
+	"money-buddy-backend/internal/repositories"
 )
 
-type CategoryRepositorySQLC struct {
+type categoryRepositorySQLC struct {
 	q *db.Queries
 }
 
-func NewCategoryRepositorySQLC(q *db.Queries) *CategoryRepositorySQLC {
-	return &CategoryRepositorySQLC{q: q}
+func NewCategoryRepositorySQLC(q *db.Queries) repositories.CategoryRepository {
+	return &categoryRepositorySQLC{q: q}
 }
 
-func (r *CategoryRepositorySQLC) ListCategories(ctx context.Context) ([]models.Category, error) {
+func (r *categoryRepositorySQLC) ListCategories(ctx context.Context) ([]models.Category, error) {
 	items, err := r.q.ListCategories(ctx)
 	if err != nil {
 		return nil, err
@@ -36,6 +37,6 @@ func dbCategoryToModel(c db.ListCategoriesRow) models.Category {
 	}
 }
 
-func (r *CategoryRepositorySQLC) CategoryExists(ctx context.Context, id int32) (bool, error) {
+func (r *categoryRepositorySQLC) CategoryExists(ctx context.Context, id int32) (bool, error) {
 	return r.q.CategoryExists(ctx, id)
 }

--- a/infra/repository/expense_repository_sqlc.go
+++ b/infra/repository/expense_repository_sqlc.go
@@ -1,4 +1,4 @@
-package repositories
+package repository
 
 import (
 	"context"
@@ -7,6 +7,7 @@ import (
 
 	db "money-buddy-backend/db/generated"
 	"money-buddy-backend/internal/models"
+	"money-buddy-backend/internal/repositories"
 )
 
 // sqlc-backed repository
@@ -14,7 +15,7 @@ type expenseRepositorySQLC struct {
 	q *db.Queries
 }
 
-func NewExpenseRepositorySQLC(q *db.Queries) ExpenseRepository {
+func NewExpenseRepositorySQLC(q *db.Queries) repositories.ExpenseRepository {
 	return &expenseRepositorySQLC{q: q}
 }
 

--- a/infra/repository/fixed_cost_repository_sqlc.go
+++ b/infra/repository/fixed_cost_repository_sqlc.go
@@ -1,0 +1,83 @@
+package repository
+
+import (
+	"context"
+	"time"
+
+	db "money-buddy-backend/db/generated"
+	"money-buddy-backend/internal/models"
+	"money-buddy-backend/internal/repositories"
+)
+
+type fixedCostRepositorySQLC struct {
+	q *db.Queries
+}
+
+func NewFixedCostRepositorySQLC(q *db.Queries) repositories.FixedCostRepository {
+	return &fixedCostRepositorySQLC{q: q}
+}
+
+func (r *fixedCostRepositorySQLC) CreateFixedCost(ctx context.Context, userID string, name string, amount int) (models.FixedCost, error) {
+	params := db.CreateFixedCostParams{
+		UserID: userID,
+		Name:   name,
+		Amount: int32(amount),
+	}
+	row, err := r.q.CreateFixedCost(ctx, params)
+	if err != nil {
+		return models.FixedCost{}, err
+	}
+
+	return dbFixedCostToModel(row), nil
+}
+
+func (r *fixedCostRepositorySQLC) ListFixedCostsByUser(ctx context.Context, userID string) ([]models.FixedCost, error) {
+	items, err := r.q.ListFixedCostsByUser(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]models.FixedCost, 0, len(items))
+	for _, it := range items {
+		out = append(out, dbFixedCostToModel(it))
+	}
+
+	return out, nil
+}
+
+func (r *fixedCostRepositorySQLC) UpdateFixedCost(ctx context.Context, id int32, userID string, name string, amount int) error {
+	params := db.UpdateFixedCostParams{
+		ID:     id,
+		Name:   name,
+		Amount: int32(amount),
+		UserID: userID,
+	}
+	return r.q.UpdateFixedCost(ctx, params)
+}
+
+func (r *fixedCostRepositorySQLC) DeleteFixedCost(ctx context.Context, id int32, userID string) error {
+	return r.q.DeleteFixedCost(ctx, db.DeleteFixedCostParams{
+		ID:     id,
+		UserID: userID,
+	})
+}
+
+func dbFixedCostToModel(fc db.FixedCost) models.FixedCost {
+	createdAt := ""
+	if fc.CreatedAt.Valid {
+		createdAt = fc.CreatedAt.Time.Format(time.RFC3339)
+	}
+	updatedAt := ""
+	if fc.UpdatedAt.Valid {
+		updatedAt = fc.UpdatedAt.Time.Format(time.RFC3339)
+	}
+
+	return models.FixedCost{
+		ID:        int(fc.ID),
+		UserID:    fc.UserID,
+		Name:      fc.Name,
+		Amount:    int(fc.Amount),
+		CreatedAt: createdAt,
+		UpdatedAt: updatedAt,
+	}
+}

--- a/infra/repository/status.go
+++ b/infra/repository/status.go
@@ -1,4 +1,4 @@
-package repositories
+package repository
 
 import "money-buddy-backend/internal/models"
 

--- a/infra/repository/user_repository_sqlc.go
+++ b/infra/repository/user_repository_sqlc.go
@@ -1,0 +1,64 @@
+package repository
+
+import (
+	"context"
+	"time"
+
+	db "money-buddy-backend/db/generated"
+	"money-buddy-backend/internal/models"
+	"money-buddy-backend/internal/repositories"
+)
+
+type userRepositorySQLC struct {
+	q *db.Queries
+}
+
+func NewUserRepositorySQLC(q *db.Queries) repositories.UserRepository {
+	return &userRepositorySQLC{q: q}
+}
+
+func (r *userRepositorySQLC) CreateUser(ctx context.Context, id string, income int, savingGoal int) error {
+	params := db.CreateUserParams{
+		ID:         id,
+		Income:     int32(income),
+		SavingGoal: int32(savingGoal),
+	}
+	return r.q.CreateUser(ctx, params)
+}
+
+func (r *userRepositorySQLC) GetUserByID(ctx context.Context, id string) (models.User, error) {
+	row, err := r.q.GetUserByID(ctx, id)
+	if err != nil {
+		return models.User{}, err
+	}
+
+	return dbUserToModel(row), nil
+}
+
+func (r *userRepositorySQLC) UpdateUserSettings(ctx context.Context, id string, income int, savingGoal int) error {
+	params := db.UpdateUserSettingsParams{
+		ID:         id,
+		Income:     int32(income),
+		SavingGoal: int32(savingGoal),
+	}
+	return r.q.UpdateUserSettings(ctx, params)
+}
+
+func dbUserToModel(u db.User) models.User {
+	createdAt := ""
+	if u.CreatedAt.Valid {
+		createdAt = u.CreatedAt.Time.Format(time.RFC3339)
+	}
+	updatedAt := ""
+	if u.UpdatedAt.Valid {
+		updatedAt = u.UpdatedAt.Time.Format(time.RFC3339)
+	}
+
+	return models.User{
+		ID:         u.ID,
+		Income:     int(u.Income),
+		SavingGoal: int(u.SavingGoal),
+		CreatedAt:  createdAt,
+		UpdatedAt:  updatedAt,
+	}
+}

--- a/internal/models/fixed_cost.go
+++ b/internal/models/fixed_cost.go
@@ -1,0 +1,10 @@
+package models
+
+type FixedCost struct {
+	ID        int    `json:"id"`
+	UserID    string `json:"user_id"`
+	Name      string `json:"name"`
+	Amount    int    `json:"amount"`
+	CreatedAt string `json:"created_at"`
+	UpdatedAt string `json:"updated_at"`
+}

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -1,0 +1,9 @@
+package models
+
+type User struct {
+	ID         string `json:"id"`
+	Income     int    `json:"income"`
+	SavingGoal int    `json:"saving_goal"`
+	CreatedAt  string `json:"created_at"`
+	UpdatedAt  string `json:"updated_at"`
+}

--- a/internal/repositories/fixed_cost_repository.go
+++ b/internal/repositories/fixed_cost_repository.go
@@ -1,0 +1,14 @@
+package repositories
+
+import (
+	"context"
+
+	"money-buddy-backend/internal/models"
+)
+
+type FixedCostRepository interface {
+	CreateFixedCost(ctx context.Context, userID string, name string, amount int) (models.FixedCost, error)
+	ListFixedCostsByUser(ctx context.Context, userID string) ([]models.FixedCost, error)
+	UpdateFixedCost(ctx context.Context, id int32, userID string, name string, amount int) error
+	DeleteFixedCost(ctx context.Context, id int32, userID string) error
+}

--- a/internal/repositories/user_repository.go
+++ b/internal/repositories/user_repository.go
@@ -1,0 +1,13 @@
+package repositories
+
+import (
+	"context"
+
+	"money-buddy-backend/internal/models"
+)
+
+type UserRepository interface {
+	CreateUser(ctx context.Context, id string, income int, savingGoal int) error
+	GetUserByID(ctx context.Context, id string) (models.User, error)
+	UpdateUserSettings(ctx context.Context, id string, income int, savingGoal int) error
+}


### PR DESCRIPTION
- closes: nt624/money-buddy#38 
## 概要
初期設定（ユーザー設定・固定費）のRepositoryを追加し、sqlc実装の配置を外部層（infra）に統一しました。

## 変更内容（詳細）
### 1. Repository interface 追加
- `UserRepository`
  - `CreateUser`
  - `GetUserByID`
  - `UpdateUserSettings`
- `FixedCostRepository`
  - `CreateFixedCost`
  - `ListFixedCostsByUser`
  - `UpdateFixedCost`
  - `DeleteFixedCost`

### 2. sqlc 実装追加（infra）
- `user_repository_sqlc.go`
  - `db.Queries` をラップし、`CreateUser / GetUserByID / UpdateUserSettings` を実装
  - `db.User` → `models.User` への変換を追加（日時はRFC3339文字列化）
- `fixed_cost_repository_sqlc.go`
  - `CreateFixedCost / ListFixedCostsByUser / UpdateFixedCost / DeleteFixedCost` を実装
  - `db.FixedCost` → `models.FixedCost` への変換を追加（日時はRFC3339文字列化）

### 3. 既存 sqlc 実装の配置整理
- `internal/repositories/*_sqlc.go` を repository へ移動
  - category_repository_sqlc.go
  - expense_repository_sqlc.go
  - status.go
- main.go のDIを repository 側に差し替え

## 動作確認
- `go test money-buddy.`

## 備考
- Service/Handler は未実装  
- Dashboard（集計）系は未変更  