### PR TITLE
#48 サービス層の実装を追加する

### DIFF
--- a/db/query/fixed_costs.sql
+++ b/db/query/fixed_costs.sql
@@ -20,6 +20,21 @@ FROM fixed_costs
 WHERE user_id = $1
 ORDER BY id ASC;
 
+-- name: DeleteFixedCostsByUser :exec
+DELETE FROM fixed_costs
+WHERE user_id = $1;
+
+-- name: BulkCreateFixedCosts :exec
+INSERT INTO fixed_costs (
+  user_id,
+  name,
+  amount
+)
+SELECT u.user_id, n.name, a.amount
+FROM UNNEST($1::text[]) WITH ORDINALITY AS u(user_id, ord)
+JOIN UNNEST($2::text[]) WITH ORDINALITY AS n(name, ord) USING (ord)
+JOIN UNNEST($3::int[]) WITH ORDINALITY AS a(amount, ord) USING (ord);
+
 -- name: UpdateFixedCost :exec
 UPDATE fixed_costs
 SET

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/quic-go/qpack v0.5.1 // indirect
 	github.com/quic-go/quic-go v0.54.0 // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.3.0 // indirect
 	go.uber.org/mock v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -53,6 +53,8 @@ github.com/quic-go/quic-go v0.54.0/go.mod h1:e68ZEaCdyviluZmy44P6Iey98v/Wfz6HCjQ
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
+github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=

--- a/infra/repository/fixed_cost_repository_sqlc.go
+++ b/infra/repository/fixed_cost_repository_sqlc.go
@@ -45,6 +45,32 @@ func (r *fixedCostRepositorySQLC) ListFixedCostsByUser(ctx context.Context, user
 	return out, nil
 }
 
+func (r *fixedCostRepositorySQLC) DeleteFixedCostsByUser(ctx context.Context, userID string) error {
+	return r.q.DeleteFixedCostsByUser(ctx, userID)
+}
+
+func (r *fixedCostRepositorySQLC) BulkCreateFixedCosts(ctx context.Context, userID string, fixedCosts []models.FixedCostInput) error {
+	if len(fixedCosts) == 0 {
+		return nil
+	}
+
+	userIDs := make([]string, 0, len(fixedCosts))
+	names := make([]string, 0, len(fixedCosts))
+	amounts := make([]int32, 0, len(fixedCosts))
+	for _, fc := range fixedCosts {
+		userIDs = append(userIDs, userID)
+		names = append(names, fc.Name)
+		amounts = append(amounts, int32(fc.Amount))
+	}
+
+	params := db.BulkCreateFixedCostsParams{
+		Column1: userIDs,
+		Column2: names,
+		Column3: amounts,
+	}
+	return r.q.BulkCreateFixedCosts(ctx, params)
+}
+
 func (r *fixedCostRepositorySQLC) UpdateFixedCost(ctx context.Context, id int32, userID string, name string, amount int) error {
 	params := db.UpdateFixedCostParams{
 		ID:     id,

--- a/internal/models/fixed_cost.go
+++ b/internal/models/fixed_cost.go
@@ -8,3 +8,8 @@ type FixedCost struct {
 	CreatedAt string `json:"created_at"`
 	UpdatedAt string `json:"updated_at"`
 }
+
+type FixedCostInput struct {
+	Name   string `json:"name"`
+	Amount int    `json:"amount"`
+}

--- a/internal/repositories/fixed_cost_repository.go
+++ b/internal/repositories/fixed_cost_repository.go
@@ -9,6 +9,8 @@ import (
 type FixedCostRepository interface {
 	CreateFixedCost(ctx context.Context, userID string, name string, amount int) (models.FixedCost, error)
 	ListFixedCostsByUser(ctx context.Context, userID string) ([]models.FixedCost, error)
+	DeleteFixedCostsByUser(ctx context.Context, userID string) error
+	BulkCreateFixedCosts(ctx context.Context, userID string, fixedCosts []models.FixedCostInput) error
 	UpdateFixedCost(ctx context.Context, id int32, userID string, name string, amount int) error
 	DeleteFixedCost(ctx context.Context, id int32, userID string) error
 }

--- a/internal/services/initial_setup_service.go
+++ b/internal/services/initial_setup_service.go
@@ -1,0 +1,82 @@
+package services
+
+import (
+	"context"
+	"database/sql"
+
+	"money-buddy-backend/internal/models"
+	"money-buddy-backend/internal/repositories"
+)
+
+type InitialSetupService interface {
+	CompleteInitialSetup(ctx context.Context, userID string, income, savingGoal int, fixedCosts []models.FixedCostInput) error
+}
+
+type initialSetupService struct {
+	userRepo      repositories.UserRepository
+	fixedCostRepo repositories.FixedCostRepository
+	txManager     TxManager
+}
+
+func NewInitialSetupService(userRepo repositories.UserRepository, fixedCostRepo repositories.FixedCostRepository, txManager TxManager) InitialSetupService {
+	return &initialSetupService{
+		userRepo:      userRepo,
+		fixedCostRepo: fixedCostRepo,
+		txManager:     txManager,
+	}
+}
+
+func (s *initialSetupService) CompleteInitialSetup(ctx context.Context, userID string, income, savingGoal int, fixedCosts []models.FixedCostInput) error {
+	if income <= 0 {
+		return &ValidationError{Message: "income must be greater than 0"}
+	}
+	if savingGoal < 0 {
+		return &ValidationError{Message: "saving_goal must be greater than or equal to 0"}
+	}
+	for _, fc := range fixedCosts {
+		if fc.Amount <= 0 {
+			return &ValidationError{Message: "fixed_cost.amount must be greater than 0"}
+		}
+		if fc.Name == "" {
+			return &ValidationError{Message: "fixed_cost.name must be provided"}
+		}
+	}
+
+	tx, err := s.txManager.Begin(ctx)
+	if err != nil {
+		return err
+	}
+
+	user, err := s.userRepo.GetUserByID(ctx, userID)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			if err := s.userRepo.CreateUser(ctx, userID, income, savingGoal); err != nil {
+				_ = tx.Rollback()
+				return err
+			}
+		} else {
+			_ = tx.Rollback()
+			return err
+		}
+	} else if user != (models.User{}) {
+		if err := s.userRepo.UpdateUserSettings(ctx, userID, income, savingGoal); err != nil {
+			_ = tx.Rollback()
+			return err
+		}
+	}
+
+	if err := s.fixedCostRepo.DeleteFixedCostsByUser(ctx, userID); err != nil {
+		_ = tx.Rollback()
+		return err
+	}
+	if err := s.fixedCostRepo.BulkCreateFixedCosts(ctx, userID, fixedCosts); err != nil {
+		_ = tx.Rollback()
+		return err
+	}
+
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/services/initial_setup_service_test.go
+++ b/internal/services/initial_setup_service_test.go
@@ -1,0 +1,235 @@
+package services
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"money-buddy-backend/internal/models"
+)
+
+type txMock struct{ mock.Mock }
+
+type txManagerMock struct{ mock.Mock }
+
+type userRepoMock struct{ mock.Mock }
+
+type fixedCostRepoMock struct{ mock.Mock }
+
+func (m *txMock) Commit() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *txMock) Rollback() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *txManagerMock) Begin(ctx context.Context) (Tx, error) {
+	args := m.Called(ctx)
+	if tx, ok := args.Get(0).(Tx); ok {
+		return tx, args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
+func (m *userRepoMock) CreateUser(ctx context.Context, id string, income int, savingGoal int) error {
+	args := m.Called(ctx, id, income, savingGoal)
+	return args.Error(0)
+}
+
+func (m *userRepoMock) GetUserByID(ctx context.Context, id string) (models.User, error) {
+	args := m.Called(ctx, id)
+	if u, ok := args.Get(0).(models.User); ok {
+		return u, args.Error(1)
+	}
+	return models.User{}, args.Error(1)
+}
+
+func (m *userRepoMock) UpdateUserSettings(ctx context.Context, id string, income int, savingGoal int) error {
+	args := m.Called(ctx, id, income, savingGoal)
+	return args.Error(0)
+}
+
+func (m *fixedCostRepoMock) CreateFixedCost(ctx context.Context, userID string, name string, amount int) (models.FixedCost, error) {
+	args := m.Called(ctx, userID, name, amount)
+	if fc, ok := args.Get(0).(models.FixedCost); ok {
+		return fc, args.Error(1)
+	}
+	return models.FixedCost{}, args.Error(1)
+}
+
+func (m *fixedCostRepoMock) ListFixedCostsByUser(ctx context.Context, userID string) ([]models.FixedCost, error) {
+	args := m.Called(ctx, userID)
+	if list, ok := args.Get(0).([]models.FixedCost); ok {
+		return list, args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
+func (m *fixedCostRepoMock) DeleteFixedCostsByUser(ctx context.Context, userID string) error {
+	args := m.Called(ctx, userID)
+	return args.Error(0)
+}
+
+func (m *fixedCostRepoMock) BulkCreateFixedCosts(ctx context.Context, userID string, fixedCosts []models.FixedCostInput) error {
+	args := m.Called(ctx, userID, fixedCosts)
+	return args.Error(0)
+}
+
+func (m *fixedCostRepoMock) UpdateFixedCost(ctx context.Context, id int32, userID string, name string, amount int) error {
+	args := m.Called(ctx, id, userID, name, amount)
+	return args.Error(0)
+}
+
+func (m *fixedCostRepoMock) DeleteFixedCost(ctx context.Context, id int32, userID string) error {
+	args := m.Called(ctx, id, userID)
+	return args.Error(0)
+}
+
+func TestCompleteInitialSetup(t *testing.T) {
+	userID := "user-1"
+	validFixedCosts := []models.FixedCostInput{
+		{Name: "rent", Amount: 50000},
+		{Name: "phone", Amount: 6000},
+	}
+
+	cases := []struct {
+		name         string
+		income       int
+		savingGoal   int
+		fixedCosts   []models.FixedCostInput
+		setupMocks   func(tx *txMock, tm *txManagerMock, ur *userRepoMock, fr *fixedCostRepoMock, calls *[]string)
+		wantErr      bool
+		wantValidate bool
+		wantCommit   bool
+		wantRollback bool
+		wantCalls    []string
+	}{
+		{
+			name:       "正常系",
+			income:     300000,
+			savingGoal: 50000,
+			fixedCosts: validFixedCosts,
+			setupMocks: func(tx *txMock, tm *txManagerMock, ur *userRepoMock, fr *fixedCostRepoMock, calls *[]string) {
+				tm.On("Begin", mock.Anything).Run(func(args mock.Arguments) { *calls = append(*calls, "begin") }).Return(tx, nil)
+				ur.On("GetUserByID", mock.Anything, userID).Run(func(args mock.Arguments) { *calls = append(*calls, "get_user") }).Return(models.User{}, sql.ErrNoRows)
+				ur.On("CreateUser", mock.Anything, userID, 300000, 50000).Run(func(args mock.Arguments) { *calls = append(*calls, "create_user") }).Return(nil)
+				fr.On("DeleteFixedCostsByUser", mock.Anything, userID).Run(func(args mock.Arguments) { *calls = append(*calls, "delete_fixed") }).Return(nil)
+				fr.On("BulkCreateFixedCosts", mock.Anything, userID, validFixedCosts).Run(func(args mock.Arguments) { *calls = append(*calls, "bulk_create") }).Return(nil)
+				tx.On("Commit").Run(func(args mock.Arguments) { *calls = append(*calls, "commit") }).Return(nil)
+			},
+			wantCommit:   true,
+			wantRollback: false,
+			wantCalls:    []string{"begin", "get_user", "create_user", "delete_fixed", "bulk_create", "commit"},
+		},
+		{
+			name:         "income が 0 以下でエラー",
+			income:       0,
+			savingGoal:   0,
+			fixedCosts:   validFixedCosts,
+			setupMocks:   func(tx *txMock, tm *txManagerMock, ur *userRepoMock, fr *fixedCostRepoMock, calls *[]string) {},
+			wantErr:      true,
+			wantValidate: true,
+		},
+		{
+			name:         "固定費 amount が 0 以下でエラー",
+			income:       100,
+			savingGoal:   0,
+			fixedCosts:   []models.FixedCostInput{{Name: "rent", Amount: 0}},
+			setupMocks:   func(tx *txMock, tm *txManagerMock, ur *userRepoMock, fr *fixedCostRepoMock, calls *[]string) {},
+			wantErr:      true,
+			wantValidate: true,
+		},
+		{
+			name:       "fixed_costs 削除失敗で rollback",
+			income:     100,
+			savingGoal: 0,
+			fixedCosts: validFixedCosts,
+			setupMocks: func(tx *txMock, tm *txManagerMock, ur *userRepoMock, fr *fixedCostRepoMock, calls *[]string) {
+				tm.On("Begin", mock.Anything).Run(func(args mock.Arguments) { *calls = append(*calls, "begin") }).Return(tx, nil)
+				ur.On("GetUserByID", mock.Anything, userID).Run(func(args mock.Arguments) { *calls = append(*calls, "get_user") }).Return(models.User{ID: userID}, nil)
+				ur.On("UpdateUserSettings", mock.Anything, userID, 100, 0).Run(func(args mock.Arguments) { *calls = append(*calls, "update_user") }).Return(nil)
+				fr.On("DeleteFixedCostsByUser", mock.Anything, userID).Run(func(args mock.Arguments) { *calls = append(*calls, "delete_fixed") }).Return(errors.New("delete failed"))
+				tx.On("Rollback").Run(func(args mock.Arguments) { *calls = append(*calls, "rollback") }).Return(nil)
+			},
+			wantErr:      true,
+			wantCommit:   false,
+			wantRollback: true,
+			wantCalls:    []string{"begin", "get_user", "update_user", "delete_fixed", "rollback"},
+		},
+		{
+			name:       "fixed_costs 作成失敗で rollback",
+			income:     100,
+			savingGoal: 0,
+			fixedCosts: validFixedCosts,
+			setupMocks: func(tx *txMock, tm *txManagerMock, ur *userRepoMock, fr *fixedCostRepoMock, calls *[]string) {
+				tm.On("Begin", mock.Anything).Run(func(args mock.Arguments) { *calls = append(*calls, "begin") }).Return(tx, nil)
+				ur.On("GetUserByID", mock.Anything, userID).Run(func(args mock.Arguments) { *calls = append(*calls, "get_user") }).Return(models.User{ID: userID}, nil)
+				ur.On("UpdateUserSettings", mock.Anything, userID, 100, 0).Run(func(args mock.Arguments) { *calls = append(*calls, "update_user") }).Return(nil)
+				fr.On("DeleteFixedCostsByUser", mock.Anything, userID).Run(func(args mock.Arguments) { *calls = append(*calls, "delete_fixed") }).Return(nil)
+				fr.On("BulkCreateFixedCosts", mock.Anything, userID, validFixedCosts).Run(func(args mock.Arguments) { *calls = append(*calls, "bulk_create") }).Return(errors.New("bulk failed"))
+				tx.On("Rollback").Run(func(args mock.Arguments) { *calls = append(*calls, "rollback") }).Return(nil)
+			},
+			wantErr:      true,
+			wantCommit:   false,
+			wantRollback: true,
+			wantCalls:    []string{"begin", "get_user", "update_user", "delete_fixed", "bulk_create", "rollback"},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			tx := &txMock{}
+			tm := &txManagerMock{}
+			ur := &userRepoMock{}
+			fr := &fixedCostRepoMock{}
+			calls := []string{}
+
+			if tc.setupMocks != nil {
+				tc.setupMocks(tx, tm, ur, fr, &calls)
+			}
+
+			s := NewInitialSetupService(ur, fr, tm)
+			err := s.CompleteInitialSetup(context.Background(), userID, tc.income, tc.savingGoal, tc.fixedCosts)
+
+			if tc.wantErr {
+				assert.Error(t, err)
+				if tc.wantValidate {
+					var ve *ValidationError
+					assert.ErrorAs(t, err, &ve)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+
+			if tc.wantCalls != nil {
+				assert.Equal(t, tc.wantCalls, calls)
+			}
+
+			if tc.wantCommit {
+				tx.AssertCalled(t, "Commit")
+			} else {
+				tx.AssertNotCalled(t, "Commit")
+			}
+			if tc.wantRollback {
+				tx.AssertCalled(t, "Rollback")
+			} else {
+				tx.AssertNotCalled(t, "Rollback")
+			}
+
+			tm.AssertExpectations(t)
+			ur.AssertExpectations(t)
+			fr.AssertExpectations(t)
+			tx.AssertExpectations(t)
+		})
+	}
+}

--- a/internal/services/tx_manager.go
+++ b/internal/services/tx_manager.go
@@ -1,0 +1,14 @@
+package services
+
+import "context"
+
+// Tx はトランザクションの最小インターフェースです。
+type Tx interface {
+	Commit() error
+	Rollback() error
+}
+
+// TxManager はトランザクション開始を担うインターフェースです。
+type TxManager interface {
+	Begin(ctx context.Context) (Tx, error)
+}


### PR DESCRIPTION
- closes: nt624/money-buddy#38 
## 概要
初期設定（ユーザー設定・固定費）ユースケース向けに、サービス層・リポジトリ拡張・テスト・トランザクション抽象を追加しました。

## 変更内容（詳細）
### 1. FixedCost のクエリ拡張
- 固定費を user_id で全削除するクエリを追加
- 固定費をまとめて登録するバルクINSERTクエリを追加  
  ※ `:copyfrom` は非対応のため、`UNNEST + WITH ORDINALITY` 方式に変更

### 2. リポジトリ拡張
- `FixedCostRepository` に以下を追加  
  - `DeleteFixedCostsByUser`  
  - `BulkCreateFixedCosts`
- sqlc 実装で上記のメソッドを実装

### 3. モデル追加
- 固定費の入力モデル `FixedCostInput` を追加（fixed_cost.go に統合）

### 4. 初期設定サービス
- `InitialSetupService` / `CompleteInitialSetup` を追加
- バリデーション（income / savingGoal / fixedCosts）
- 仕様に基づく処理順（Begin → upsert → delete → bulk insert → commit）
- エラー時は rollback

### 5. トランザクション抽象
- `Tx` / `TxManager` の interface を追加

### 6. テスト
- `InitialSetupService` のテストを table-driven で追加
- `testify/mock` を利用

## 影響範囲
- 既存の service/handler への変更なし  
- DB クエリ拡張に伴い sqlc 生成物が更新対象

## 既知の留意点
- `TxManager` の実装（infra）は未追加  
- Repository が tx を受け取る構成は未対応（今後の実装で反映）