### PR TITLE
#48 ハンドラーの追加

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -40,5 +40,11 @@ func main() {
 	categoryService := services.NewCategoryService(categoryRepo)
 	handlers.NewCategoryHandler(r, categoryService)
 
+	userRepo := repository.NewUserRepositorySQLC(queries)
+	fixedCostRepo := repository.NewFixedCostRepositorySQLC(queries)
+	txManager := db.NewSQLTxManager(dbConn)
+	initialSetupService := services.NewInitialSetupService(userRepo, fixedCostRepo, txManager)
+	handlers.NewInitialSetupHandler(r, initialSetupService)
+
 	r.Run() // デフォルトで:8080で起動
 }

--- a/internal/db/tx_manager.go
+++ b/internal/db/tx_manager.go
@@ -1,0 +1,20 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+
+	"money-buddy-backend/internal/services"
+)
+
+type SQLTxManager struct {
+	db *sql.DB
+}
+
+func NewSQLTxManager(db *sql.DB) *SQLTxManager {
+	return &SQLTxManager{db: db}
+}
+
+func (m *SQLTxManager) Begin(ctx context.Context) (services.Tx, error) {
+	return m.db.BeginTx(ctx, nil)
+}

--- a/internal/handlers/initial_setup_handler.go
+++ b/internal/handlers/initial_setup_handler.go
@@ -1,0 +1,55 @@
+package handlers
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"money-buddy-backend/internal/models"
+	"money-buddy-backend/internal/services"
+)
+
+type InitialSetupHandler struct {
+	service services.InitialSetupService
+}
+
+type initialSetupRequest struct {
+	Income     int                     `json:"income"`
+	SavingGoal int                     `json:"savingGoal"`
+	FixedCosts []models.FixedCostInput `json:"fixedCosts"`
+}
+
+func NewInitialSetupHandler(r *gin.Engine, service services.InitialSetupService) {
+	h := &InitialSetupHandler{service: service}
+	r.POST("/api/setup", h.CompleteInitialSetup)
+}
+
+func (h *InitialSetupHandler) CompleteInitialSetup(c *gin.Context) {
+	var req initialSetupRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	// TODO: Extract userID from authentication context when auth is implemented
+	userID := DummyUserID
+
+	err := h.service.CompleteInitialSetup(c.Request.Context(), userID, req.Income, req.SavingGoal, req.FixedCosts)
+	if err != nil {
+		var ve *services.ValidationError
+		if errors.As(err, &ve) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": ve.Message})
+			return
+		}
+		var be *services.NotFoundError
+		if errors.As(err, &be) {
+			c.JSON(http.StatusUnprocessableEntity, gin.H{"error": be.Message})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"status": "ok"})
+}

--- a/internal/handlers/initial_setup_handler_test.go
+++ b/internal/handlers/initial_setup_handler_test.go
@@ -1,0 +1,146 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+
+	"money-buddy-backend/internal/models"
+	"money-buddy-backend/internal/services"
+)
+
+type initialSetupServiceMock struct {
+	CompleteInitialSetupFunc func(userID string, income, savingGoal int, fixedCosts []models.FixedCostInput) error
+}
+
+func (m *initialSetupServiceMock) CompleteInitialSetup(ctx context.Context, userID string, income, savingGoal int, fixedCosts []models.FixedCostInput) error {
+	if m.CompleteInitialSetupFunc != nil {
+		return m.CompleteInitialSetupFunc(userID, income, savingGoal, fixedCosts)
+	}
+	return nil
+}
+
+func TestInitialSetupHandler_OK(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+
+	called := false
+	svc := &initialSetupServiceMock{
+		CompleteInitialSetupFunc: func(userID string, income, savingGoal int, fixedCosts []models.FixedCostInput) error {
+			called = true
+			require.Equal(t, DummyUserID, userID)
+			require.Equal(t, 300000, income)
+			require.Equal(t, 50000, savingGoal)
+			require.Equal(t, []models.FixedCostInput{{Name: "家賃", Amount: 80000}, {Name: "通信費", Amount: 5000}}, fixedCosts)
+			return nil
+		},
+	}
+	NewInitialSetupHandler(router, svc)
+
+	body := `{"income":300000,"savingGoal":50000,"fixedCosts":[{"name":"家賃","amount":80000},{"name":"通信費","amount":5000}]}`
+	req := httptest.NewRequest(http.MethodPost, "/api/setup", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.True(t, called)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp map[string]string
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Equal(t, "ok", resp["status"])
+}
+
+func TestInitialSetupHandler_InvalidJSON(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+
+	svc := &initialSetupServiceMock{}
+	NewInitialSetupHandler(router, svc)
+
+	body := `{"income":"bad"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/setup", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestInitialSetupHandler_ValidationError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+
+	svc := &initialSetupServiceMock{
+		CompleteInitialSetupFunc: func(userID string, income, savingGoal int, fixedCosts []models.FixedCostInput) error {
+			return &services.ValidationError{Message: "income must be greater than 0"}
+		},
+	}
+	NewInitialSetupHandler(router, svc)
+
+	body := `{"income":0,"savingGoal":0,"fixedCosts":[]}`
+	req := httptest.NewRequest(http.MethodPost, "/api/setup", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	var resp map[string]string
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Equal(t, "income must be greater than 0", resp["error"])
+}
+
+func TestInitialSetupHandler_BusinessError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+
+	svc := &initialSetupServiceMock{
+		CompleteInitialSetupFunc: func(userID string, income, savingGoal int, fixedCosts []models.FixedCostInput) error {
+			return &services.NotFoundError{Message: "user not found"}
+		},
+	}
+	NewInitialSetupHandler(router, svc)
+
+	body := `{"income":100,"savingGoal":0,"fixedCosts":[]}`
+	req := httptest.NewRequest(http.MethodPost, "/api/setup", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusUnprocessableEntity, w.Code)
+	var resp map[string]string
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Equal(t, "user not found", resp["error"])
+}
+
+func TestInitialSetupHandler_InternalError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+
+	svc := &initialSetupServiceMock{
+		CompleteInitialSetupFunc: func(userID string, income, savingGoal int, fixedCosts []models.FixedCostInput) error {
+			return errors.New("boom")
+		},
+	}
+	NewInitialSetupHandler(router, svc)
+
+	body := `{"income":100,"savingGoal":0,"fixedCosts":[]}`
+	req := httptest.NewRequest(http.MethodPost, "/api/setup", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusInternalServerError, w.Code)
+}

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -9,6 +9,8 @@ tags:
     description: "Expense operations"
   - name: "categories"
     description: "Category operations"
+  - name: "setup"
+    description: "Initial setup operations"
 paths:
   /expenses:
     post:
@@ -158,6 +160,43 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /api/setup:
+    post:
+      tags:
+        - "setup"
+      summary: "Complete initial setup"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/InitialSetupRequest'
+      responses:
+        "200":
+          description: "Initial setup completed"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InitialSetupResponse'
+        "400":
+          description: "Validation Error"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "422":
+          description: "Business Error"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: "Internal Server Error"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
 components:
   schemas:
     Expense:
@@ -258,6 +297,36 @@ components:
         - category_id
         - spent_at
 
+    FixedCostInput:
+      type: object
+      properties:
+        name:
+          type: string
+        amount:
+          type: integer
+          minimum: 1
+      required:
+        - name
+        - amount
+
+    InitialSetupRequest:
+      type: object
+      properties:
+        income:
+          type: integer
+          minimum: 1
+        savingGoal:
+          type: integer
+          minimum: 0
+        fixedCosts:
+          type: array
+          items:
+            $ref: '#/components/schemas/FixedCostInput'
+      required:
+        - income
+        - savingGoal
+        - fixedCosts
+
     UpdateExpenseResponse:
       type: object
       properties:
@@ -265,6 +334,15 @@ components:
           $ref: '#/components/schemas/Expense'
       required:
         - expense
+
+    InitialSetupResponse:
+      type: object
+      properties:
+        status:
+          type: string
+          example: "ok"
+      required:
+        - status
 
     ErrorResponse:
       type: object


### PR DESCRIPTION
- closes: nt624/money-buddy#38 
## 概要
初期設定API（POST /api/setup）のハンドラーとOpenAPI定義を追加しました。  
サービス層のバリデーション/業務エラーをHTTPステータスへ正しくマッピングし、ハンドラーはサービス呼び出しのみに留めています。

## 変更点
- 初期設定APIハンドラー追加（JSONバインド → `InitialSetupService` 呼び出しのみ）
- エラーマッピング追加  
  - `ValidationError` → 400  
  - 業務エラー → 422  
  - その他 → 500
- 初期設定ハンドラーのテスト追加（正常/JSON不正/validation/business/internal）
- SQLTxManagerの実装追加（初期設定処理のトランザクション開始に利用）
- OpenAPIに /api/setup と関連スキーマ（InitialSetupRequest/Response, FixedCostInput）を追加

## 変更理由・根拠
- 仕様にある「ハンドラーはロジックを書かない」を満たすため、検証や処理はサービス層に集約。
- 仕様のステータスコード要件（400/422/500）を満たすため、サービスエラー型で分岐。
- API追加に合わせてOpenAPIを更新し、フロント/外部連携の契約を明確化。
- ハンドラーの挙動はサービスの変更に影響されにくいため、先行してテストを追加。

## 動作確認
- テスト未実行（必要なら実行します）

## 備考
- Firebase Auth の user_id 取得は既存の仮実装（DummyUserID）のままです