### PR TITLE
#52 トランザクションを追加する

### DIFF
--- a/infra/transaction/tx_manager_sql.go
+++ b/infra/transaction/tx_manager_sql.go
@@ -7,6 +7,17 @@ import (
 	"money-buddy-backend/internal/services"
 )
 
+type txKey struct{}
+
+func withTx(ctx context.Context, tx *sql.Tx) context.Context {
+	return context.WithValue(ctx, txKey{}, tx)
+}
+
+func TxFromContext(ctx context.Context) (*sql.Tx, bool) {
+	tx, ok := ctx.Value(txKey{}).(*sql.Tx)
+	return tx, ok
+}
+
 type sqlTx struct {
 	tx *sql.Tx
 }
@@ -17,6 +28,10 @@ func (t *sqlTx) Commit() error {
 
 func (t *sqlTx) Rollback() error {
 	return t.tx.Rollback()
+}
+
+func (t *sqlTx) Context(ctx context.Context) context.Context {
+	return withTx(ctx, t.tx)
 }
 
 type sqlTxManager struct {

--- a/infra/transaction/tx_manager_sql.go
+++ b/infra/transaction/tx_manager_sql.go
@@ -1,0 +1,36 @@
+package transaction
+
+import (
+	"context"
+	"database/sql"
+
+	"money-buddy-backend/internal/services"
+)
+
+type sqlTx struct {
+	tx *sql.Tx
+}
+
+func (t *sqlTx) Commit() error {
+	return t.tx.Commit()
+}
+
+func (t *sqlTx) Rollback() error {
+	return t.tx.Rollback()
+}
+
+type sqlTxManager struct {
+	db *sql.DB
+}
+
+func NewTxManager(db *sql.DB) services.TxManager {
+	return &sqlTxManager{db: db}
+}
+
+func (m *sqlTxManager) Begin(ctx context.Context) (services.Tx, error) {
+	tx, err := m.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &sqlTx{tx: tx}, nil
+}

--- a/internal/db/tx_manager.go
+++ b/internal/db/tx_manager.go
@@ -1,20 +1,13 @@
 package db
 
 import (
-	"context"
 	"database/sql"
 
+	"money-buddy-backend/infra/transaction"
 	"money-buddy-backend/internal/services"
 )
 
-type SQLTxManager struct {
-	db *sql.DB
-}
-
-func NewSQLTxManager(db *sql.DB) *SQLTxManager {
-	return &SQLTxManager{db: db}
-}
-
-func (m *SQLTxManager) Begin(ctx context.Context) (services.Tx, error) {
-	return m.db.BeginTx(ctx, nil)
+// NewSQLTxManager は TxManager の infra 実装を返します。
+func NewSQLTxManager(db *sql.DB) services.TxManager {
+	return transaction.NewTxManager(db)
 }

--- a/internal/services/initial_setup_service_test.go
+++ b/internal/services/initial_setup_service_test.go
@@ -30,6 +30,10 @@ func (m *txMock) Rollback() error {
 	return args.Error(0)
 }
 
+func (m *txMock) Context(ctx context.Context) context.Context {
+	return ctx
+}
+
 func (m *txManagerMock) Begin(ctx context.Context) (Tx, error) {
 	args := m.Called(ctx)
 	if tx, ok := args.Get(0).(Tx); ok {

--- a/internal/services/tx_manager.go
+++ b/internal/services/tx_manager.go
@@ -6,6 +6,7 @@ import "context"
 type Tx interface {
 	Commit() error
 	Rollback() error
+	Context(ctx context.Context) context.Context
 }
 
 // TxManager はトランザクション開始を担うインターフェースです。


### PR DESCRIPTION
- closes: nt624/money-buddy#39 
## 概要
初期設定ユースケースで**トランザクションが実際に効く**ように、`TxManager` の infra 実装と repository へのトランザクション導線を追加しました。  
既存のサービス層は interface 依存のままに保ち、外部層で tx 実装を差し込む構成です。

## 変更内容（詳細）
### 1. TxManager の infra 実装
- `database/sql` の `BeginTx` を使った `TxManager` を追加
- `Tx` から tx を埋め込んだ `context` を取得できるように拡張

### 2. Service から tx context を利用
- 初期設定サービスが `tx.Context(ctx)` を使って repository を呼び出すように変更

### 3. Repository 側の tx 対応
- `context` から tx を取り出し、`sqlc` の `Queries.WithTx` を使用
- トランザクションあり/なしで同じ repository 実装が動作する構成に

### 4. wiring
- `internal/db.NewSQLTxManager` で infra 実装を返すように変更  
  （main 側は変更不要で注入可能）

## 変更の意図
- サービス層は interface のみに依存し続ける（Clean Architecture）
- 実DB操作は外部層で完結させ、**実際に 1 トランザクションで処理される**ことを保証する

## 現在の状況 / 留意点
- 既存サービス層テストで rollback 呼び出しは検証済み
- 実際の DB でのトランザクション保証は、統合テスト/動作確認でチェックする想定

## 動作確認
- `go test money-buddy.`  
（必要に応じて `/api/setup` を叩いて users / fixed_costs の更新が同一トランザクションで行われることを確認）

---