### PR TITLE
#55 GET /user/me APIを追加する

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -46,5 +46,8 @@ func main() {
 	initialSetupService := services.NewInitialSetupService(userRepo, fixedCostRepo, txManager)
 	handlers.NewInitialSetupHandler(r, initialSetupService)
 
+	userService := services.NewUserService(userRepo)
+	handlers.NewUserHandler(r, userService)
+
 	r.Run() // デフォルトで:8080で起動
 }

--- a/internal/handlers/initial_setup_handler.go
+++ b/internal/handlers/initial_setup_handler.go
@@ -22,7 +22,7 @@ type initialSetupRequest struct {
 
 func NewInitialSetupHandler(r *gin.Engine, service services.InitialSetupService) {
 	h := &InitialSetupHandler{service: service}
-	r.POST("/api/setup", h.CompleteInitialSetup)
+	r.POST("/setup", h.CompleteInitialSetup)
 }
 
 func (h *InitialSetupHandler) CompleteInitialSetup(c *gin.Context) {

--- a/internal/handlers/initial_setup_handler_test.go
+++ b/internal/handlers/initial_setup_handler_test.go
@@ -45,7 +45,7 @@ func TestInitialSetupHandler_OK(t *testing.T) {
 	NewInitialSetupHandler(router, svc)
 
 	body := `{"income":300000,"savingGoal":50000,"fixedCosts":[{"name":"家賃","amount":80000},{"name":"通信費","amount":5000}]}`
-	req := httptest.NewRequest(http.MethodPost, "/api/setup", strings.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, "/setup", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 
 	w := httptest.NewRecorder()
@@ -67,7 +67,7 @@ func TestInitialSetupHandler_InvalidJSON(t *testing.T) {
 	NewInitialSetupHandler(router, svc)
 
 	body := `{"income":"bad"}`
-	req := httptest.NewRequest(http.MethodPost, "/api/setup", strings.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, "/setup", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 
 	w := httptest.NewRecorder()
@@ -88,7 +88,7 @@ func TestInitialSetupHandler_ValidationError(t *testing.T) {
 	NewInitialSetupHandler(router, svc)
 
 	body := `{"income":0,"savingGoal":0,"fixedCosts":[]}`
-	req := httptest.NewRequest(http.MethodPost, "/api/setup", strings.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, "/setup", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 
 	w := httptest.NewRecorder()
@@ -112,7 +112,7 @@ func TestInitialSetupHandler_BusinessError(t *testing.T) {
 	NewInitialSetupHandler(router, svc)
 
 	body := `{"income":100,"savingGoal":0,"fixedCosts":[]}`
-	req := httptest.NewRequest(http.MethodPost, "/api/setup", strings.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, "/setup", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 
 	w := httptest.NewRecorder()
@@ -136,7 +136,7 @@ func TestInitialSetupHandler_InternalError(t *testing.T) {
 	NewInitialSetupHandler(router, svc)
 
 	body := `{"income":100,"savingGoal":0,"fixedCosts":[]}`
-	req := httptest.NewRequest(http.MethodPost, "/api/setup", strings.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, "/setup", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 
 	w := httptest.NewRecorder()

--- a/internal/handlers/user_handler.go
+++ b/internal/handlers/user_handler.go
@@ -1,0 +1,31 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"money-buddy-backend/internal/services"
+)
+
+type UserHandler struct {
+	service services.UserService
+}
+
+func NewUserHandler(r *gin.Engine, service services.UserService) {
+	h := &UserHandler{service: service}
+	r.GET("/user/me", h.GetCurrentUser)
+}
+
+func (h *UserHandler) GetCurrentUser(c *gin.Context) {
+	// TODO: Extract userID from authentication context when auth is implemented
+	userID := DummyUserID
+
+	user, err := h.service.GetUserByID(c.Request.Context(), userID)
+	if err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "user not found"})
+		return
+	}
+
+	c.JSON(http.StatusOK, user)
+}

--- a/internal/handlers/user_handler_test.go
+++ b/internal/handlers/user_handler_test.go
@@ -1,0 +1,104 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+
+	"money-buddy-backend/internal/models"
+)
+
+type userServiceMock struct {
+	GetUserByIDFunc func(ctx context.Context, userID string) (*models.User, error)
+}
+
+func (m *userServiceMock) GetUserByID(ctx context.Context, userID string) (*models.User, error) {
+	if m.GetUserByIDFunc != nil {
+		return m.GetUserByIDFunc(ctx, userID)
+	}
+	return nil, nil
+}
+
+func TestUserHandler_GetCurrentUser_Success(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+
+	svc := &userServiceMock{
+		GetUserByIDFunc: func(ctx context.Context, userID string) (*models.User, error) {
+			require.Equal(t, DummyUserID, userID)
+			return &models.User{
+				ID:         "test-user",
+				Income:     300000,
+				SavingGoal: 50000,
+				CreatedAt:  "2024-01-01T00:00:00Z",
+				UpdatedAt:  "2024-01-01T00:00:00Z",
+			}, nil
+		},
+	}
+	NewUserHandler(router, svc)
+
+	req := httptest.NewRequest(http.MethodGet, "/user/me", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var user models.User
+	err := json.Unmarshal(w.Body.Bytes(), &user)
+	require.NoError(t, err)
+	require.Equal(t, "test-user", user.ID)
+	require.Equal(t, 300000, user.Income)
+	require.Equal(t, 50000, user.SavingGoal)
+}
+
+func TestUserHandler_GetCurrentUser_NotFound(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+
+	svc := &userServiceMock{
+		GetUserByIDFunc: func(ctx context.Context, userID string) (*models.User, error) {
+			return nil, errors.New("user not found")
+		},
+	}
+	NewUserHandler(router, svc)
+
+	req := httptest.NewRequest(http.MethodGet, "/user/me", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusNotFound, w.Code)
+
+	var resp map[string]string
+	err := json.Unmarshal(w.Body.Bytes(), &resp)
+	require.NoError(t, err)
+	require.Equal(t, "user not found", resp["error"])
+}
+
+func TestUserHandler_GetCurrentUser_RepositoryError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+
+	svc := &userServiceMock{
+		GetUserByIDFunc: func(ctx context.Context, userID string) (*models.User, error) {
+			return nil, errors.New("database connection error")
+		},
+	}
+	NewUserHandler(router, svc)
+
+	req := httptest.NewRequest(http.MethodGet, "/user/me", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusNotFound, w.Code)
+
+	var resp map[string]string
+	err := json.Unmarshal(w.Body.Bytes(), &resp)
+	require.NoError(t, err)
+	require.Equal(t, "user not found", resp["error"])
+}

--- a/internal/services/user_service.go
+++ b/internal/services/user_service.go
@@ -1,0 +1,30 @@
+package services
+
+import (
+	"context"
+
+	"money-buddy-backend/internal/models"
+	"money-buddy-backend/internal/repositories"
+)
+
+type UserService interface {
+	GetUserByID(ctx context.Context, userID string) (*models.User, error)
+}
+
+type userService struct {
+	userRepo repositories.UserRepository
+}
+
+func NewUserService(userRepo repositories.UserRepository) UserService {
+	return &userService{
+		userRepo: userRepo,
+	}
+}
+
+func (s *userService) GetUserByID(ctx context.Context, userID string) (*models.User, error) {
+	user, err := s.userRepo.GetUserByID(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	return &user, nil
+}

--- a/internal/services/user_service_test.go
+++ b/internal/services/user_service_test.go
@@ -1,0 +1,87 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"money-buddy-backend/internal/models"
+)
+
+type mockUserRepo struct {
+	getUserByIDFunc func(ctx context.Context, id string) (models.User, error)
+}
+
+func (m *mockUserRepo) CreateUser(ctx context.Context, id string, income int, savingGoal int) error {
+	return errors.New("not implemented")
+}
+
+func (m *mockUserRepo) GetUserByID(ctx context.Context, id string) (models.User, error) {
+	if m.getUserByIDFunc != nil {
+		return m.getUserByIDFunc(ctx, id)
+	}
+	return models.User{}, errors.New("not implemented")
+}
+
+func (m *mockUserRepo) UpdateUserSettings(ctx context.Context, id string, income int, savingGoal int) error {
+	return errors.New("not implemented")
+}
+
+func TestUserService_GetUserByID_Success(t *testing.T) {
+	expectedUser := models.User{
+		ID:         "test-user",
+		Income:     300000,
+		SavingGoal: 50000,
+		CreatedAt:  "2024-01-01T00:00:00Z",
+		UpdatedAt:  "2024-01-01T00:00:00Z",
+	}
+
+	repo := &mockUserRepo{
+		getUserByIDFunc: func(ctx context.Context, id string) (models.User, error) {
+			assert.Equal(t, "test-user", id)
+			return expectedUser, nil
+		},
+	}
+
+	service := NewUserService(repo)
+	user, err := service.GetUserByID(context.Background(), "test-user")
+
+	require.NoError(t, err)
+	require.NotNil(t, user)
+	assert.Equal(t, "test-user", user.ID)
+	assert.Equal(t, 300000, user.Income)
+	assert.Equal(t, 50000, user.SavingGoal)
+}
+
+func TestUserService_GetUserByID_NotFound(t *testing.T) {
+	repo := &mockUserRepo{
+		getUserByIDFunc: func(ctx context.Context, id string) (models.User, error) {
+			return models.User{}, errors.New("user not found")
+		},
+	}
+
+	service := NewUserService(repo)
+	user, err := service.GetUserByID(context.Background(), "non-existent-user")
+
+	require.Error(t, err)
+	require.Nil(t, user)
+	assert.Contains(t, err.Error(), "user not found")
+}
+
+func TestUserService_GetUserByID_RepositoryError(t *testing.T) {
+	repo := &mockUserRepo{
+		getUserByIDFunc: func(ctx context.Context, id string) (models.User, error) {
+			return models.User{}, errors.New("database connection error")
+		},
+	}
+
+	service := NewUserService(repo)
+	user, err := service.GetUserByID(context.Background(), "test-user")
+
+	require.Error(t, err)
+	require.Nil(t, user)
+	assert.Contains(t, err.Error(), "database connection error")
+}

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -9,6 +9,8 @@ tags:
     description: "Expense operations"
   - name: "categories"
     description: "Category operations"
+  - name: "users"
+    description: "User operations"
   - name: "setup"
     description: "Initial setup operations"
 paths:
@@ -160,7 +162,26 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
-  /api/setup:
+  /user/me:
+    get:
+      tags:
+        - "users"
+      summary: "Get current user information"
+      responses:
+        "200":
+          description: "User information"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+        "404":
+          description: "User not found (initial setup not completed)"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /setup:
     post:
       tags:
         - "setup"
@@ -216,7 +237,32 @@ components:
           type: string
           enum: [planned, confirmed]
           description: "Expense status. Allowed values are 'planned' or 'confirmed'. Note: Status transition rule on update: 'confirmed' -> 'planned' is prohibited; 'planned' -> 'confirmed' is allowed."
-        category:
+        catego
+
+    User:
+      type: object
+      properties:
+        id:
+          type: string
+          description: "User ID (Firebase UID)"
+        income:
+          type: integer
+          description: "Monthly income (take-home)"
+        saving_goal:
+          type: integer
+          description: "Monthly saving goal"
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+      required:
+        - id
+        - income
+        - saving_goal
+        - created_at
+        - updated_atry:
           $ref: '#/components/schemas/Category'
       required:
         - id


### PR DESCRIPTION
## 概要
ユーザー情報取得API（GET /user/me）を追加し、フロントエンドから初期設定完了状態を確認できるようにしました。
また、APIエンドポイントの一貫性を保つため、初期設定APIのパスを `/api/setup` → `/setup` に変更しました。

## 変更内容

### 1. APIエンドポイントの統一
- **変更前**: `POST /api/setup`
- **変更後**: `POST /setup`
- **理由**: 他のエンドポイント（`/expenses`, `/categories`）との一貫性を保つため

### 2. ユーザー情報取得API追加
新規エンドポイント: **`GET /user/me`**

**レスポンス例**:
```json
{
  "id": "test-user",
  "income": 300000,
  "saving_goal": 50000,
  "created_at": "2024-01-01T00:00:00Z",
  "updated_at": "2024-01-01T00:00:00Z"
}
```

**404 Not Found の場合**:
```json
{
  "error": "user not found"
}
```

### 3. 実装ファイル

#### 新規作成
- user_service.go - ユーザー情報取得のサービス層
- user_service_test.go - UserService のテスト
- user_handler.go - GET /user/me のハンドラー
- user_handler_test.go - UserHandler のテスト

#### 変更
- initial_setup_handler.go - `/api/setup` → `/setup` に変更
- initial_setup_handler_test.go - テストのパスを修正
- main.go - UserService と UserHandler の配線追加

## フロントエンドでの利用方法

### 初期設定完了判定
```typescript
// ログイン後に実行
const res = await fetch('http://localhost:8080/user/me');

if (res.status === 404) {
  // ユーザーレコード未作成 → 初期設定画面へ
  router.push('/setup');
} else {
  // 初期設定済み → ダッシュボードへ
  const user = await res.json();
  router.push('/dashboard');
}
```

### フロー全体
```
1. Firebase Auth でログイン → UID取得
   ↓
2. GET /user/me をコール
   ↓
3-A. 404 Not Found
     → 初期設定画面へ遷移
     → POST /setup で usersレコード + fixed_costs 作成
   ↓
3-B. 200 OK
     → ダッシュボードへ遷移
```

## 設計方針

### 認証とアプリケーションDBの分離
- **Firebase Auth**: 認証専用（email, password, UID管理）
- **usersテーブル**: アプリ固有データ（income, saving_goal）

### 初期設定のタイミング
- Firebase Authでの認証時には usersテーブルにレコードを作成しない
- 初期設定API（POST /setup）で初めて usersレコード作成
- これにより「認証」と「アプリデータ初期化」の責任を分離

## テスト

すべてのテストが成功することを確認済み：
```bash
$ go test ./...
ok      money-buddy-backend/internal/handlers   0.273s
ok      money-buddy-backend/internal/services   0.264s
```

### テストカバレッジ
- UserService: 正常系、NotFound、リポジトリエラー
- UserHandler: 200 OK、404 Not Found、エラー処理

## 動作確認用curlコマンド

```bash
# ユーザー情報取得
curl -X GET http://localhost:8080/user/me

# 初期設定（パス変更後）
curl -X POST http://localhost:8080/setup \
  -H "Content-Type: application/json" \
  -d '{"income":300000,"savingGoal":50000,"fixedCosts":[{"name":"家賃","amount":80000}]}'
```

## 関連Issue
- closes: nt624/money-buddy#40
